### PR TITLE
Update build steps for GitHub test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v4
       - name: Build
-        run: make build
+        run: swift build
       - name: Run tests
-        run: make test
+        run: swift test --disable-xctest 2>&1 | xcbeautify


### PR DESCRIPTION
Update to not call the `make` targets, instead call `swift` directly, and pipe test output to `xcbeautify`.