### PR TITLE
Add support for parsing the leader key syntax

### DIFF
--- a/Sources/skbdlib/Parser.swift
+++ b/Sources/skbdlib/Parser.swift
@@ -27,7 +27,7 @@ public class Parser {
       if check(type: .modifier) {
         shortcuts.append(try parseShortcut())
       } else {
-        throw ParserError.expectedModifier
+        throw ParserError.expectedModifierOrLeader
       }
     }
 

--- a/Sources/skbdlib/ParserError.swift
+++ b/Sources/skbdlib/ParserError.swift
@@ -4,6 +4,7 @@ enum ParserError: Error {
   case expectedModifierFollowedByDash
   case expectedDashFollowedByKey
   case expectedColonFollowedByCommand
+  case leaderKeyAlreadySet
 }
 
 extension ParserError: CustomStringConvertible {
@@ -19,6 +20,8 @@ extension ParserError: CustomStringConvertible {
       return "expected key to follow dash"
     case .expectedColonFollowedByCommand:
       return "expected command to follow colon"
+    case .leaderKeyAlreadySet:
+      return "leader key has already been set"
     }
   }
 }

--- a/Sources/skbdlib/ParserError.swift
+++ b/Sources/skbdlib/ParserError.swift
@@ -1,5 +1,5 @@
 enum ParserError: Error {
-  case expectedModifier
+  case expectedModifierOrLeader
   case expectedPlusFollowedByModifier
   case expectedModifierFollowedByDash
   case expectedDashFollowedByKey
@@ -9,8 +9,8 @@ enum ParserError: Error {
 extension ParserError: CustomStringConvertible {
   public var description: String {
     switch self {
-    case .expectedModifier:
-      return "expected modifier"
+    case .expectedModifierOrLeader:
+      return "expected modifier or leader directive"
     case .expectedPlusFollowedByModifier:
       return "expected modifier to follow plus"
     case .expectedModifierFollowedByDash:

--- a/Sources/skbdlib/Shortcut.swift
+++ b/Sources/skbdlib/Shortcut.swift
@@ -1,13 +1,13 @@
 import Carbon
 import Foundation
 
-public typealias CommandHandler = () throws -> Void
+public typealias HandlerFunc = () throws -> Void
 
 public struct Shortcut {
-  public static func handler(for command: String) -> CommandHandler {
+  public static func handler(for command: String) -> HandlerFunc {
     let shell = ProcessInfo.processInfo.environment["SHELL"].flatMap { $0.isEmpty ? nil : $0 } ?? "/bin/bash"
 
-    let handler: CommandHandler = {
+    let handler: HandlerFunc = {
       if command.isEmpty {
         return
       }
@@ -23,7 +23,7 @@ public struct Shortcut {
   public var keyCode: UInt32?
   public var modifierFlags: UInt32?
 
-  public var handler: CommandHandler!
+  public var handler: HandlerFunc!
 
   public init() {}
 
@@ -32,7 +32,7 @@ public struct Shortcut {
     self.modifierFlags = modifierFlags
   }
 
-  public init(_ keyCode: UInt32, _ modifierFlags: UInt32, _ handler: @escaping CommandHandler) {
+  public init(_ keyCode: UInt32, _ modifierFlags: UInt32, _ handler: @escaping HandlerFunc) {
     self.keyCode = keyCode
     self.modifierFlags = modifierFlags
     self.handler = handler

--- a/Sources/skbdlib/Shortcut.swift
+++ b/Sources/skbdlib/Shortcut.swift
@@ -20,6 +20,8 @@ public struct Shortcut {
 
   public let identifier = UUID()
 
+  public var isLeader: Bool = false
+
   public var keyCode: UInt32?
   public var modifierFlags: UInt32?
 


### PR DESCRIPTION
Add parsing of the `leader: <modifier> - <key>` syntax, which is currently tokenized by the `Lexer`.

- Rename `.expectedModifier` error to `expectedModifierOrLeader` since, we expect a modifier or leader directive
- Add `.leaderKeyAlreadySet` error, since we expect there to only be 1 leader key set
- Rename `CommandHandler` to `HandlerFunc`, since it won't only for for commands, but handling when the leader key is pressed too
- Add `isLeader` property to `Shortcut`, since it will need to be found to be able to add the custom handler for a leader key
- Update the `parse` method of `Parser` to handle parsing a leader key shortcut, and refactor other methods accordingly