### PR TITLE
Add parsing of leader shortcuts (sequence shortcuts)

### DIFF
--- a/Sources/skbdlib/Lexer.swift
+++ b/Sources/skbdlib/Lexer.swift
@@ -5,6 +5,8 @@ class Lexer {
     static let comment = Character("#")
     static let plus = Character("+")
     static let dash = Character("-")
+    static let keywordStart = Character("<")
+    static let keywordEnd = Character(">")
     static let colon = Character(":")
 
     static let singleCharKeys: Set<Character> = ["`", "=", "[", "]", ";", "'", "\\", ",", ".", "/"]
@@ -48,6 +50,14 @@ class Lexer {
     case Special.dash:
       advance()
       return Token(type: .dash)
+
+    case Special.keywordStart:
+      advance()
+      return Token(type: .keywordStart)
+
+    case Special.keywordEnd:
+      advance()
+      return Token(type: .keywordEnd)
 
     case _ where Special.singleCharKeys.contains(current):
       return handleSingleCharKey()

--- a/Sources/skbdlib/ParserError.swift
+++ b/Sources/skbdlib/ParserError.swift
@@ -1,10 +1,13 @@
 enum ParserError: Error {
   case expectedModifierOrLeader
+  case expectedKey
   case expectedPlusFollowedByModifier
   case expectedModifierFollowedByDash
   case expectedDashFollowedByKey
   case expectedColonFollowedByCommand
   case leaderKeyAlreadySet
+  case expectedLeaderKeyword
+  case expectedKeywordEnd
 }
 
 extension ParserError: CustomStringConvertible {
@@ -12,6 +15,8 @@ extension ParserError: CustomStringConvertible {
     switch self {
     case .expectedModifierOrLeader:
       return "expected modifier or leader directive"
+    case .expectedKey:
+      return "expected key"
     case .expectedPlusFollowedByModifier:
       return "expected modifier to follow plus"
     case .expectedModifierFollowedByDash:
@@ -22,6 +27,10 @@ extension ParserError: CustomStringConvertible {
       return "expected command to follow colon"
     case .leaderKeyAlreadySet:
       return "leader key has already been set"
+    case .expectedLeaderKeyword:
+      return "expected leader keyword after keyword start"
+    case .expectedKeywordEnd:
+      return "expected keyword end after keyword"
     }
   }
 }

--- a/Sources/skbdlib/TokenType.swift
+++ b/Sources/skbdlib/TokenType.swift
@@ -3,6 +3,9 @@ enum TokenType {
 
   case leader
 
+  case keywordStart
+  case keywordEnd
+
   case modifier
   case key
   case command
@@ -21,6 +24,10 @@ extension TokenType: CustomStringConvertible {
       return "TokenType {Comment}"
     case .leader:
       return "TokenType {Leader}"
+    case .keywordStart:
+      return "TokenType {Keyword Start}"
+    case .keywordEnd:
+      return "TokenType {Keyword End}"
     case .modifier:
       return "TokenType {Modifier}"
     case .key:

--- a/Tests/skbdlibTests/LexerTests.swift
+++ b/Tests/skbdlibTests/LexerTests.swift
@@ -30,6 +30,15 @@ struct LexerTests {
 
           # this makes sure we allow - as a key
           cmd + shift + opt - -: echo "hyphen!"
+
+          # this is a leader key mapping with a single key
+          <leader> a: echo "Hello"
+
+          # this is a leader key mapping with a group key
+          <leader> b c: echo "Hello"
+
+          # this is a leader key mapping with a same group key
+          <leader> b d: echo "Hello"
       """
 
     let expected: [TokenType] = [
@@ -47,6 +56,12 @@ struct LexerTests {
       .modifier, .dash, .key, .command,
       .comment,
       .modifier, .plus, .modifier, .plus, .modifier, .dash, .dash, .command,
+      .comment,
+      .keywordStart, .leader, .keywordEnd, .key, .command,
+      .comment,
+      .keywordStart, .leader, .keywordEnd, .key, .key, .command,
+      .comment,
+      .keywordStart, .leader, .keywordEnd, .key, .key, .command,
     ]
 
     let lexer = Lexer(input)

--- a/Tests/skbdlibTests/ParserTests.swift
+++ b/Tests/skbdlibTests/ParserTests.swift
@@ -7,8 +7,8 @@ import Testing
 struct ParserTests {
   // MARK: - Parser#parse
 
-  @Test("Parser#parse() (with valid input)")
-  func parseWithValidInput() async throws {
+  @Test("Parser#parse() (with modifier shortcuts)")
+  func parseWithModifierShortcuts() async throws {
     let input = """
           # this if the first comment, without whitespace
           opt-space:open -a iTerm2.app
@@ -30,9 +30,6 @@ struct ParserTests {
           # this is a mapping with a number key
           ctrl + shift - 5: cat ~/.config/skbd/skbdrc | pbcopy
 
-          # this is a leader mappign
-          leader: ctrl - space
-
           # can use key symbols
           alt - [: echo "left bracket"
       """
@@ -43,42 +40,91 @@ struct ParserTests {
       struct Expect {
         var key: UInt32
         var modifiers: UInt32
-        var leader: Bool
         var action: Bool
       }
 
       let expected = [
-        Expect(key: UInt32(kVK_Space), modifiers: UInt32(optionKey), leader: false, action: true),
-        Expect(key: UInt32(kVK_ANSI_A), modifiers: UInt32(cmdKey | shiftKey), leader: false, action: true),
-        Expect(key: UInt32(kVK_Return), modifiers: UInt32(controlKey | optionKey), leader: false, action: true),
-        Expect(
-          key: UInt32(kVK_Space),
-          modifiers: UInt32(controlKey | optionKey | shiftKey),
-          leader: false,
-          action: true
-        ),
-        Expect(
-          key: UInt32(kVK_F1),
-          modifiers: UInt32(controlKey | optionKey | cmdKey | shiftKey),
-          leader: false,
-          action: true
-        ),
-        Expect(key: UInt32(kVK_ANSI_5), modifiers: UInt32(controlKey | shiftKey), leader: false, action: true),
-        Expect(key: UInt32(kVK_Space), modifiers: UInt32(controlKey), leader: true, action: false),
-        Expect(key: UInt32(kVK_ANSI_LeftBracket), modifiers: UInt32(optionKey), leader: false, action: true),
+        Expect(key: UInt32(kVK_Space), modifiers: UInt32(optionKey), action: true),
+        Expect(key: UInt32(kVK_ANSI_A), modifiers: UInt32(cmdKey | shiftKey), action: true),
+        Expect(key: UInt32(kVK_Return), modifiers: UInt32(controlKey | optionKey), action: true),
+        Expect(key: UInt32(kVK_Space), modifiers: UInt32(controlKey | optionKey | shiftKey), action: true),
+        Expect(key: UInt32(kVK_F1), modifiers: UInt32(controlKey | optionKey | cmdKey | shiftKey), action: true),
+        Expect(key: UInt32(kVK_ANSI_5), modifiers: UInt32(controlKey | shiftKey), action: true),
+        Expect(key: UInt32(kVK_ANSI_LeftBracket), modifiers: UInt32(optionKey), action: true),
       ]
 
-      #expect(shortcuts.count == 8)
+      #expect(shortcuts.count == expected.count)
 
       for (idx, expect) in expected.enumerated() {
         if let modifierShortcut = shortcuts[idx] as? ModifierShortcut {
           #expect(modifierShortcut.keyCode == expect.key)
           #expect(modifierShortcut.modifierFlags == expect.modifiers)
           #expect((modifierShortcut.action != nil) == expect.action)
-        } else if let leaderShortcut = shortcuts[idx] as? LeaderShortcut {
-          #expect(leaderShortcut.keyCode == expect.key)
-          #expect(leaderShortcut.modifierFlags == expect.modifiers)
-          #expect((leaderShortcut.action != nil) == expect.action)
+        }
+      }
+    }
+  }
+
+  @Test("Parser#parse() (with leader shortcut)")
+  func parseWithLeaderShortcut() async throws {
+    let input = """
+          # this setting the leader key shortcut
+          leader: ctrl - space
+      """
+
+    #expect(throws: Never.self) {
+      let shortcuts = try Parser(input).parse()
+
+      struct Expect {
+        var key: UInt32
+        var modifiers: UInt32
+        var action: Bool
+      }
+
+      let expected = [
+        Expect(key: UInt32(kVK_Space), modifiers: UInt32(controlKey), action: false)
+      ]
+
+      #expect(shortcuts.count == expected.count)
+
+      for (idx, expect) in expected.enumerated() {
+        if let modifierShortcut = shortcuts[idx] as? LeaderShortcut {
+          #expect(modifierShortcut.keyCode == expect.key)
+          #expect(modifierShortcut.modifierFlags == expect.modifiers)
+          #expect((modifierShortcut.action != nil) == expect.action)
+        }
+      }
+    }
+  }
+
+  @Test("Parser#parse() (with sequence shortcuts in input)")
+  func parseWithSequenceShortcuts() async throws {
+    let input = """
+        <leader> o b c: echo "leader o b c"
+
+        <leader> o b s: echo "leader o b s"
+
+        <leader> o b f: echo "leader o b f"
+      """
+
+    #expect(throws: Never.self) {
+      let shortcuts = try Parser(input).parse()
+
+      struct Expect {
+        var keys: [UInt32]
+      }
+
+      let expected = [
+        Expect(keys: [UInt32(kVK_ANSI_O), UInt32(kVK_ANSI_B), UInt32(kVK_ANSI_C)]),
+        Expect(keys: [UInt32(kVK_ANSI_O), UInt32(kVK_ANSI_B), UInt32(kVK_ANSI_S)]),
+        Expect(keys: [UInt32(kVK_ANSI_O), UInt32(kVK_ANSI_B), UInt32(kVK_ANSI_F)]),
+      ]
+
+      #expect(shortcuts.count == expected.count)
+
+      for (idx, expect) in expected.enumerated() {
+        if let sequenceShortcut = shortcuts[idx] as? SequenceShortcut {
+          #expect(sequenceShortcut.keyCodes == expect.keys)
         }
       }
     }
@@ -87,47 +133,63 @@ struct ParserTests {
   @Test("Parser#parse() (with comment in input)")
   func parseWithComment() async throws {
     #expect(throws: Never.self) {
-      try Parser("# this is just a comment").parse()
+      let shortcuts = try Parser("# this is just a comment").parse()
+
+      #expect(shortcuts.count == 0)
     }
   }
 
-  @Test("Parser#parse() (with no modifier or leader directive in input)")
-  func parseWithNoModifiers() async throws {
+  @Test("Parser#parse() (with no modifier or leader)")
+  func parseWithNoModifierOrLeader() async throws {
     #expect(throws: ParserError.expectedModifierOrLeader) {
       try Parser("space: open -a iTerm2.app").parse()
     }
   }
 
-  @Test("Parser#parse() (with no additional modifier in input)")
-  func parseWithNoAdditionalModifier() async throws {
+  @Test("Parser#parse() (with missing key)")
+  func parseWithMissingKey() async throws {
+    #expect(throws: ParserError.expectedKey) {
+      try Parser("<leader> : true").parse()
+    }
+  }
+
+  @Test("Parser#parse() (with invalid key)")
+  func parseWithInvalidKey() async throws {
+    #expect(throws: ParserError.expectedKey) {
+      try Parser("<leader> >: true").parse()
+    }
+  }
+
+  @Test("Parser#parse() (with no modifier after plus)")
+  func parseWithNoModifierAfterPlus() async throws {
     #expect(throws: ParserError.expectedPlusFollowedByModifier) {
       try Parser("opt + : open -a iTerm2.app").parse()
     }
   }
 
-  @Test("Parser#parse() (with no dash after modifier in input)")
+  @Test("Parser#parse() (with no dash after modifier)")
   func parseWithNoDashAfterModifier() async throws {
     #expect(throws: ParserError.expectedModifierFollowedByDash) {
       try Parser("opt + ctrl : open -a iTerm2.app").parse()
     }
   }
 
-  @Test("Parser#parse() (with no key after dash in input)")
+  @Test("Parser#parse() (with no key after dash)")
   func parseWithNoKeyAfterDash() async throws {
     #expect(throws: ParserError.expectedDashFollowedByKey) {
       try Parser("opt + ctrl - : open -a iTerm2.app").parse()
     }
   }
 
-  @Test("Parser#parse() (with no command in input)")
-  func parseWithNoCommand() async throws {
+  @Test("Parser#parse() (with no command after modifier shortcut)")
+  func parseWithNoCommandAfterModifierShortcut() async throws {
     #expect(throws: ParserError.expectedColonFollowedByCommand) {
       try Parser("opt+ctrl-a+opt").parse()
     }
   }
 
-  @Test("Parser#parse() (with multiple leader directives)")
-  func parseWithMultipleLeaders() async throws {
+  @Test("Parser#parse() (with multiple set leader)")
+  func parseWithMultipleSetLeader() async throws {
     #expect(throws: ParserError.leaderKeyAlreadySet) {
       let input = """
           leader: ctrl - space
@@ -135,6 +197,27 @@ struct ParserTests {
         """
 
       _ = try Parser(input).parse()
+    }
+  }
+
+  @Test("Parser#parse() (with invalid keyword)")
+  func parseWithInvalidKeyword() async throws {
+    #expect(throws: ParserError.expectedLeaderKeyword) {
+      try Parser("<foobar> a b c: true").parse()
+    }
+  }
+
+  @Test("Parser#parse() (with missing keyword end)")
+  func parseWithMissingKeywordEnd() async throws {
+    #expect(throws: ParserError.expectedKeywordEnd) {
+      try Parser("<leader a b c: true").parse()
+    }
+  }
+
+  @Test("Parser#parse() (with no command after sequence shortcut)")
+  func parseWithNoCommandAfterSequence() async throws {
+    #expect(throws: ParserError.expectedColonFollowedByCommand) {
+      try Parser("<leader> a b c").parse()
     }
   }
 }

--- a/Tests/skbdlibTests/Resources/Fixtures/skbd/skbdrc1
+++ b/Tests/skbdlibTests/Resources/Fixtures/skbd/skbdrc1
@@ -1,1 +1,5 @@
 ctrl - space: echo "Hello World"
+
+leader: cmd - space
+
+<leader> o b: echo "open browser"

--- a/Tests/skbdlibTests/Resources/Fixtures/skbdrc
+++ b/Tests/skbdlibTests/Resources/Fixtures/skbdrc
@@ -1,1 +1,5 @@
 ctrl - space: echo "Hello world"
+
+leader: cmd - space
+
+<leader> b s: echo "open browser"

--- a/Tests/skbdlibTests/TokenTypeTests.swift
+++ b/Tests/skbdlibTests/TokenTypeTests.swift
@@ -10,6 +10,8 @@ struct TokenTypeTests {
   func description() async throws {
     let tests: [TokenType: String] = [
       .leader: "TokenType {Leader}",
+      .keywordStart: "TokenType {Keyword Start}",
+      .keywordEnd: "TokenType {Keyword End}",
       .comment: "TokenType {Comment}",
       .modifier: "TokenType {Modifier}",
       .key: "TokenType {Key}",


### PR DESCRIPTION
Add the parsing of leader shortcuts (called sequence shortcuts in project).

- Add keyword start `<` and keyword end `>` special characters
- Add parsing sequence shortcuts to the `Parser`
- Update parser tests to tests for modifier shortcuts, leader shortcuts, and sequence shortcuts