### PR TITLE
Refactor shortcut parsing

### DIFF
--- a/Sources/skbdlib/ConfigManager.swift
+++ b/Sources/skbdlib/ConfigManager.swift
@@ -61,7 +61,18 @@ public class ConfigManager {
     let shortcuts = try parser.parse()
 
     for shortcut in shortcuts {
-      shortcutManager.register(shortcut: shortcut)
+      switch shortcut {
+      case let leaderShortcut as LeaderShortcut:
+        // TODO: handle leader shortcut
+        continue
+      case let modifierShortcut as ModifierShortcut:
+        shortcutManager.register(shortcut: modifierShortcut)
+      case let sequenceShortcut as SequenceShortcut:
+        // TODO: handle sequence shortcuts
+        continue
+      default:
+        continue
+      }
     }
   }
 }

--- a/Sources/skbdlib/LeaderShortcut.swift
+++ b/Sources/skbdlib/LeaderShortcut.swift
@@ -1,0 +1,16 @@
+import Carbon
+import Foundation
+
+struct LeaderShortcut: Shortcut {
+  var action: Action!
+
+  let identifier = UUID()
+
+  var keyCode: UInt32
+  var modifierFlags: UInt32
+
+  init(_ keyCode: UInt32, _ modifierFlags: UInt32) {
+    self.keyCode = keyCode
+    self.modifierFlags = modifierFlags
+  }
+}

--- a/Sources/skbdlib/ModifierShortcut.swift
+++ b/Sources/skbdlib/ModifierShortcut.swift
@@ -11,11 +11,6 @@ struct ModifierShortcut: Shortcut {
   var keyCode: UInt32
   var modifierFlags: UInt32
 
-  init(_ keyCode: UInt32, _ modifierFlags: UInt32) {
-    self.keyCode = keyCode
-    self.modifierFlags = modifierFlags
-  }
-
   init(_ keyCode: UInt32, _ modifierFlags: UInt32, _ action: @escaping Action) {
     self.keyCode = keyCode
     self.modifierFlags = modifierFlags

--- a/Sources/skbdlib/SequenceShortcut.swift
+++ b/Sources/skbdlib/SequenceShortcut.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct SequenceShortcut: Shortcut {
+  var action: Action!
+
+  var keyCodes: [UInt32]?
+
+  init(_ keyCodes: [UInt32]) {
+    self.keyCodes = keyCodes
+  }
+
+  init(_ keyCodes: [UInt32], _ action: @escaping Action) {
+    self.keyCodes = keyCodes
+    self.action = action
+  }
+}

--- a/Tests/skbdlibTests/ModifierShortcutTests.swift
+++ b/Tests/skbdlibTests/ModifierShortcutTests.swift
@@ -67,8 +67,8 @@ struct ModifierShortcutTests {
 
   @Test("ModifierShortcut#identifier (identifiers are unique)")
   func identifier() async throws {
-    let shortcut1 = ModifierShortcut(1, 2)
-    let shortcut2 = ModifierShortcut(1, 2)
+    let shortcut1 = ModifierShortcut(1, 2) {}
+    let shortcut2 = ModifierShortcut(1, 2) {}
 
     #expect(shortcut1.identifier != shortcut2.identifier)
   }

--- a/Tests/skbdlibTests/ParserTests.swift
+++ b/Tests/skbdlibTests/ParserTests.swift
@@ -71,10 +71,15 @@ struct ParserTests {
       #expect(shortcuts.count == 8)
 
       for (idx, expect) in expected.enumerated() {
-        #expect(shortcuts[idx].keyCode == expect.key)
-        #expect(shortcuts[idx].modifierFlags == expect.modifiers)
-        #expect(shortcuts[idx].isLeader == expect.leader)
-        #expect((shortcuts[idx].action != nil) == expect.action)
+        if let modifierShortcut = shortcuts[idx] as? ModifierShortcut {
+          #expect(modifierShortcut.keyCode == expect.key)
+          #expect(modifierShortcut.modifierFlags == expect.modifiers)
+          #expect((modifierShortcut.action != nil) == expect.action)
+        } else if let leaderShortcut = shortcuts[idx] as? LeaderShortcut {
+          #expect(leaderShortcut.keyCode == expect.key)
+          #expect(leaderShortcut.modifierFlags == expect.modifiers)
+          #expect((leaderShortcut.action != nil) == expect.action)
+        }
       }
     }
   }

--- a/Tests/skbdlibTests/SequenceShortcutTests.swift
+++ b/Tests/skbdlibTests/SequenceShortcutTests.swift
@@ -1,0 +1,6 @@
+import Testing
+
+@testable import skbdlib
+
+@Suite("SequenceShortcut")
+struct SequenceShortcutTests {}

--- a/Tests/skbdlibTests/ShortcutManagerTests.swift
+++ b/Tests/skbdlibTests/ShortcutManagerTests.swift
@@ -30,7 +30,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#register(shortcut:) (with valid shortcut)")
   func registerValidShortcut() async throws {
-    let shortcut = ModifierShortcut(2, 456)
+    let shortcut = ModifierShortcut(2, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -39,7 +39,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#register(shortcut:) (with already registered shortcut)")
   func registerWithAlreadyRegisteredShortcut() async throws {
-    let shortcut = ModifierShortcut(3, 456)
+    let shortcut = ModifierShortcut(3, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
     shortcutManager.register(shortcut: shortcut)
@@ -51,7 +51,7 @@ class ShortcutManagerTests {
   func registerWhenRegisterEventHotKeyFails() async throws {
     shortcutManager.registerEventHotKeyFunc = { (_, _, _, _, _, _) in OSStatus(eventHotKeyInvalidErr) }
 
-    let shortcut = ModifierShortcut(6, 456)
+    let shortcut = ModifierShortcut(6, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -62,7 +62,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#unregister(shortcut:) (with registered shortcut)")
   func unregisterWithRegisteredShortcut() async throws {
-    let shortcut = ModifierShortcut(7, 456)
+    let shortcut = ModifierShortcut(7, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -75,7 +75,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#unregister(shortcut:) (with unregistered shortcut)")
   func unregisterWithUnregisteredShortcut() async throws {
-    let shortcut = ModifierShortcut(8, 456)
+    let shortcut = ModifierShortcut(8, 456) {}
 
     shortcutManager.unregister(shortcut: shortcut)
 
@@ -86,7 +86,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#start() (when shortcuts registered)")
   func startWhenShortcutsRegistered() async throws {
-    let shortcut = ModifierShortcut(9, 456)
+    let shortcut = ModifierShortcut(9, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -100,7 +100,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#start() (when already started)")
   func startWhenAlreadyStarted() async throws {
-    let shortcut = ModifierShortcut(11, 456)
+    let shortcut = ModifierShortcut(11, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -112,7 +112,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#stop() (when shortcuts registered)")
   func stopWhenShortcutsRegistered() async throws {
-    let shortcut = ModifierShortcut(12, 456)
+    let shortcut = ModifierShortcut(12, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -129,8 +129,8 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#reset() (when shortcuts registered)")
   func resetWhenShortcutsRegistered() async throws {
-    let shortcut1 = ModifierShortcut(14, 456)
-    let shortcut2 = ModifierShortcut(15, 654)
+    let shortcut1 = ModifierShortcut(14, 456) {}
+    let shortcut2 = ModifierShortcut(15, 654) {}
 
     shortcutManager.register(shortcut: shortcut1)
     shortcutManager.register(shortcut: shortcut2)
@@ -148,7 +148,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#box(for:) (with registered shortcut)")
   func boxWithRegisteredShortcut() async throws {
-    let shortcut = ModifierShortcut(16, 456)
+    let shortcut = ModifierShortcut(16, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
 
@@ -157,7 +157,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#box(for:) (with unregistered shortcut)")
   func boxWithUnregisteredShortcut() async throws {
-    let shortcut = ModifierShortcut(17, 456)
+    let shortcut = ModifierShortcut(17, 456) {}
 
     #expect(shortcutManager.box(for: shortcut) == nil)
   }
@@ -197,7 +197,7 @@ class ShortcutManagerTests {
 
   @Test("ShortcutManager#handleCarbonEvent() (with invalid signature)")
   func handleCarbonEventWithInvalidSignature() async throws {
-    let shortcut = ModifierShortcut(21, 456)
+    let shortcut = ModifierShortcut(21, 456) {}
 
     shortcutManager.register(shortcut: shortcut)
     let box = try #require(shortcutManager.box(for: shortcut))


### PR DESCRIPTION
Refactor how we parse the leader key specific shortcut.

- Add `LeaderShortcut` which is a `Shortcut` that is like a `ModifierHandler`, but it's action is constructed differently, since it will need to show and hide the key window/status item in the future, rather than run commands.
- Update `ConfigManager` to pull out `LeaderShortcuts` and `ModifierShortcuts` and handle accordingly
- Remove the `action`-less `init()` from `ModifierShortcut`
- Update `Parser` to return `[Shortcut]` rather than `[ModifierShortcut]`
- Add `SequenceShortcut` for the eventual "leader" shortcuts
- Fix tests due to refactors